### PR TITLE
Fix: own system's IP throws error now

### DIFF
--- a/sockapp/__init__.py
+++ b/sockapp/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1-alpha-5"
+__version__ = "0.1-alpha-6"

--- a/sockapp/app.py
+++ b/sockapp/app.py
@@ -46,6 +46,17 @@ def send():
         port = int(app.config.get("port", PORT))
         protocol = app.config.get("protocol", PROTOCOL)
 
+        sender_ip = get_ip()
+
+        if(sender_ip == recv_ip):
+            return jsonify(
+                {
+                    "icon": "error",
+                    "title": "Error",
+                    "status": f"{sender_ip} is this system's IP, provide receiver's IP!",
+                }
+            )
+
         if not os.path.exists(send_path):
             return jsonify(
                 {


### PR DESCRIPTION
Closes #12.

**Implementation**

Check in sender route if the recv_ip is equal to current system's IP, if they are equal then throw error. 