### PR TITLE
Fix windows style path, test files, dirs and messages

### DIFF
--- a/sockapp/app.py
+++ b/sockapp/app.py
@@ -5,6 +5,7 @@ import socket
 from . import __version__
 from .utils.ip_helpers import get_ip
 from .utils.file_dir_helpers import get_file_dir_path, untar_tarball
+from .utils.path_helpers import parse_path
 from .constants import *
 from .receiver.receiver import Receiver
 from .sender.sender import Sender
@@ -67,6 +68,10 @@ def send():
         protocol = app.config.get("protocol", PROTOCOL)
 
         sender_ip = get_ip()
+
+        send_path = parse_path(path=send_path)
+
+        print(send_path)
 
         if(sender_ip == recv_ip):
             return jsonify(

--- a/sockapp/utils/file_dir_helpers.py
+++ b/sockapp/utils/file_dir_helpers.py
@@ -15,6 +15,9 @@ def tar_dir(dir_path):
 
 def get_file_dir_path(path):
     is_dir = False
+    
+    if(path[-1] == "/"):
+        path = path[:-1]
 
     if os.path.isdir(path):
         is_dir = True

--- a/sockapp/utils/path_helpers.py
+++ b/sockapp/utils/path_helpers.py
@@ -1,0 +1,5 @@
+def parse_path(path):
+    if "\\" in path:
+        path = path.replace("\\", "/")
+
+    return path


### PR DESCRIPTION
Closes #11

**Implementation**

1. Check if path contains \ and if it does then replace it with /, python's `os.path` then parses it as path.
2. Parse the path before starting to send it, so that all paths use / format to separate dirs.

**Minor bug fix**

1. A dir path ending with / resulted in .tar.gz being created, added a check for finding if last character in path is / and if it is then removed it.

**Release**

This marks an end to 0.1-alpha-6 dev, all the issues have been closed. Pushing the newest version to pypi.