### PR TITLE
Change host -> receiver_ip acc to #4 in sockx

### DIFF
--- a/sockapp/app.py
+++ b/sockapp/app.py
@@ -99,7 +99,7 @@ def send():
 
         file_path, is_dir = get_file_dir_path(path=send_path)
         sender = Sender.get_sender(
-            host=recv_ip, port=port, protocol=protocol
+            receiver_ip=recv_ip, port=port, protocol=protocol
         )
 
         try:
@@ -141,7 +141,7 @@ def send_message():
             )
             
         sender = Sender.get_sender(
-            host=recv_ip, port=port, protocol=protocol, is_message=True
+            receiver_ip=recv_ip, port=port, protocol=protocol, is_message=True
         )
         
         try:


### PR DESCRIPTION
Closes #44

Implementation
Update host to receiver_ip in sockapp client (app.py)

Release
Code wise this marks the end to v0.1-alpha-9. Releasing this after testing.